### PR TITLE
Add error logging for failed RESTBase responses

### DIFF
--- a/src/MathRestbaseInterface.php
+++ b/src/MathRestbaseInterface.php
@@ -406,6 +406,7 @@ class MathRestbaseInterface {
 				$this->success = $json->detail->success;
 				$this->error = $json->detail;
 			} else {
+				$this->logger->error("Invalid HTTP {$response['code']} response from RESTBase: {$response['body']}");
 				$this->success = false;
 				$this->setErrorMessage( 'Math extension cannot connect to Restbase.' );
 			}


### PR DESCRIPTION
Currently, this generates an user-facing parse error, but provides no information for us.