### PR TITLE
fix: SpecialMathStatus native tests should reflect default behavior

### DIFF
--- a/src/SpecialMathStatus.php
+++ b/src/SpecialMathStatus.php
@@ -78,7 +78,7 @@ class SpecialMathStatus extends SpecialPage {
 			return;
 		}
 		$real = str_replace( "\n", '', $renderer->getHtmlOutput() );
-		$expected = '<mo>+</mo>';
+		$expected = '<mo stretchy="false">+</mo>';
 		$this->assertContains( $expected, $real, "Checking the presence of '+' in the MathML output" );
 		$this->getOutput()->addWikiMsgArray( 'math-test-end', [ $modeName ] );
 	}


### PR DESCRIPTION
Default behavior is to add the stretchy attribute to all operators, see https://github.com/Wikia/mediawiki-extensions-Math/blob/REL1_43/src/WikiTexVC/Nodes/Literal.php#L97

Created a change upstream as well https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Math/+/1104991